### PR TITLE
Update interface

### DIFF
--- a/src/model/ColumnLikeModel.cpp
+++ b/src/model/ColumnLikeModel.cpp
@@ -149,6 +149,16 @@ bool ColumnWithParticles::configure(io::IParameterProvider& paramProvider)
 {
 	ColumnLikeModel::configure(paramProvider);
 
+	if (paramProvider.exists("PAR_GEOM"))
+	{
+		std::vector<std::string> pg = paramProvider.getStringArray("PAR_GEOM");
+		for (const std::string entry : pg) {
+			if (entry != "SPHERE") {
+				throw InvalidParameterException("Only spherical particles can be simulated, but " + entry + " was specified");
+			}
+		}
+	}
+
 	int numParType = 1;
 	if (paramProvider.exists("PAR_TYPE_VOLFRAC"))
 	{

--- a/src/model/ColumnLikeModel.cpp
+++ b/src/model/ColumnLikeModel.cpp
@@ -214,9 +214,14 @@ bool ColumnWithPoreDiffusion::configure(io::IParameterProvider& paramProvider)
 {
 	ColumnWithParticles::configure(paramProvider);
 
-	paramProvider.pushScope("discretization");
-	_nBound = std::move(paramProvider.getIntArray("NBOUND"));
-	paramProvider.popScope();
+	if (paramProvider.exists("NBOUND"))
+		_nBound = std::move(paramProvider.getIntArray("NBOUND"));
+	else // backwards compatibility
+	{
+		paramProvider.pushScope("discretization");
+		_nBound = std::move(paramProvider.getIntArray("NBOUND"));
+		paramProvider.popScope();
+	}
 
 	const int numBound = std::accumulate(_nBound.begin(), _nBound.end(), 0);
 	const int numParType = _parTypeVolFrac.size();

--- a/test/EstimateTests.cpp
+++ b/test/EstimateTests.cpp
@@ -40,6 +40,7 @@ namespace
 			"PAR_POROSITY": 0.75,
 			"INIT_C": [0.0],
 			"INIT_Q": [0.0],
+			"NBOUND": [1],
 			"ADSORPTION_MODEL": "LINEAR",
 			"adsorption":
 			{
@@ -51,7 +52,6 @@ namespace
 			{
 				"NCOL": 16,
 				"NPAR": 4,
-				"NBOUND": [1],
 				"PAR_DISC_TYPE": "EQUIDISTANT_PAR",
 				"USE_ANALYTIC_JACOBIAN": true,
 				"MAX_KRYLOV": 0,

--- a/test/GRM2D.cpp
+++ b/test/GRM2D.cpp
@@ -44,6 +44,7 @@ namespace
 			"PAR_POROSITY": 0.75,
 			"INIT_C": [0.0],
 			"INIT_Q": [0.0],
+			"NBOUND": [1],
 			"ADSORPTION_MODEL": "LINEAR",
 			"adsorption":
 			{
@@ -55,7 +56,6 @@ namespace
 			{
 				"NCOL": 16,
 				"NPAR": 4,
-				"NBOUND": [1],
 				"PAR_DISC_TYPE": "EQUIDISTANT_PAR",
 				"USE_ANALYTIC_JACOBIAN": true,
 				"MAX_KRYLOV": 0,
@@ -94,6 +94,7 @@ namespace
 			"PAR_POROSITY": 0.75,
 			"INIT_C": [0.0],
 			"INIT_Q": [0.0],
+			"NBOUND": [1],
 			"ADSORPTION_MODEL": "LINEAR",
 			"adsorption":
 			{
@@ -105,7 +106,6 @@ namespace
 			{
 				"NCOL": 16,
 				"NPAR": 4,
-				"NBOUND": [1],
 				"NRAD": 1,
 				"RADIAL_COMPARTMENTS": [],
 				"RADIAL_DISC_TYPE": "EQUIDISTANT",

--- a/test/SystemTests.cpp
+++ b/test/SystemTests.cpp
@@ -40,6 +40,7 @@ namespace
 			"PAR_POROSITY": 0.75,
 			"INIT_C": [0.0],
 			"INIT_Q": [0.0],
+			"NBOUND": [1],
 			"ADSORPTION_MODEL": "LINEAR",
 			"adsorption":
 			{
@@ -51,7 +52,6 @@ namespace
 			{
 				"NCOL": 16,
 				"NPAR": 4,
-				"NBOUND": [1],
 				"PAR_DISC_TYPE": "EQUIDISTANT_PAR",
 				"USE_ANALYTIC_JACOBIAN": true,
 				"MAX_KRYLOV": 0,
@@ -90,6 +90,7 @@ namespace
 			"PAR_POROSITY": 0.75,
 			"INIT_C": [0.0],
 			"INIT_Q": [0.0],
+			"NBOUND": [1],
 			"ADSORPTION_MODEL": "LINEAR",
 			"adsorption":
 			{
@@ -101,7 +102,6 @@ namespace
 			{
 				"NCOL": 16,
 				"NPAR": 4,
-				"NBOUND": [1],
 				"NRAD": 1,
 				"RADIAL_COMPARTMENTS": [],
 				"RADIAL_DISC_TYPE": "EQUIDISTANT",


### PR DESCRIPTION
FIxes #3 so that interface complies with CADET-Core interface, including backwards compatibility, see CADET-Core/#177.
Only `NBOUND` had to be changed here, since `NPARTYPE` is infered and `PAR_GEOM` is only valid if "SPHERE" particles are used.