### PR TITLE
Adapt interface to match CADET-Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,25 @@
+{
+  "title": "CADET-Semi-Analytic: Version 1.2.0",
+  "upload_type": "software",
+  "creators": [
+    { 
+      "name": "Leweke, Samuel", 
+      "orcid": "0000-0001-9471-4511", 
+      "affiliation": "Forschungszentrum Jülich"
+    },
+    { 
+      "name": "von Lieres, Eric", 
+      "orcid": "0000-0002-0309-8408", 
+      "affiliation": "Forschungszentrum Jülich"
+    }
+  ],
+  "license": "GPL-3.0",
+  "keywords": [
+   "modeling","simulation", "biotechnology", "process", "chromatography", "CADET", "general rate model", "C++"
+  ],
+  "version": "1.2.0",
+  "access_right": "open",
+  "communities": [
+    { "identifier": "open-source" }
+  ]
+}

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,16 @@
+% As an open-source project, CADET-Semi-Analytic relies on the support and recognition from users and researchers to thrive.
+% Therefore, we kindly ask that any publications or projects leveraging the capabilities of CADET-Semi-Analytic acknowledge its creators and their contributions by citing the following publication.
+
+@article{LEWEKE2016350,
+title = {Fast arbitrary order moments and arbitrary precision solution of the general rate model of column liquid chromatography with linear isotherm},
+journal = {Computers & Chemical Engineering},
+volume = {84},
+pages = {350-362},
+year = {2016},
+issn = {0098-1354},
+doi = {https://doi.org/10.1016/j.compchemeng.2015.09.009},
+url = {https://www.sciencedirect.com/science/article/pii/S009813541500304X},
+author = {Samuel Leweke and Eric {von Lieres}},
+keywords = {Arbitrary precision solution, Arbitrary order moments, Numerical inverse Laplace transform, Error analysis, Algorithmic differentiation, Convergence acceleration},
+abstract = {Algorithms and software are presented for efficiently computing reference solutions of the general rate model with proven error bounds. Moreover, algorithms and software are presented for efficiently computing moments of arbitrary order. The methods are based on numerical inverse Laplace transform, and support both quasi-stationary and dynamic linear binding models. The inlet concentration profiles are treated in a most general way using piecewise cubic polynomials. Algorithmic differentiation obviates manual derivation of the required derivatives. Arbitrary precision arithmetics are applied for minimizing numerical roundoff errors, and several convergence acceleration techniques are evaluated. The implemented software package is freely available as open source on GitHub.}
+}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 # CADET - Semi Analytic Extension
 
-[CADET](https://cadet.github.io/) is developed at the Institute of Bio- and Geosciences 1 (IBG-1) of Forschungszentrum Jülich (FZJ) under supervision of Dr. Eric von Lieres. This is the semi analytic extension of the [CADET project](https://github.com/cadet), which is freely distributed (under the terms of the GPLv3) as a contribution to the scientific community. If you find it useful for your own work, we would appreciate acknowledgements of this software and citations of our papers:
+The Chromatography Analysis and Design Toolkit (CADET) is developed at the Institute of Bio- and Geosciences 1 (IBG-1) of Forschungszentrum Jülich (FZJ) under supervision of Prof. Eric von Lieres.
+This is the semi analytic extension of the [core CADET project](https://github.com/modsim/cadet), of which both are freely distributed (under the terms of the GPLv3) as a contribution to the scientific community.
+If you find it useful for your own work, we would appreciate acknowledgements of this software and citations of our papers:
 
 * S. Leweke, E. von Lieres (2016): [Fast arbitrary order moments and arbitrary precision solution of the general rate model of column liquid chromatography with linear isotherm](https://doi.org/10.1016/j.compchemeng.2015.09.009), Computers & Chemical Engineering, 84, 350–362.
+
+Please note that the results from the referenced publication can be reproduced exactly using version 1 of the software, which is saved in a [dedicated branch](https://github.com/cadet/CADET-Semi-Analytic/tree/v1.2.1).
 
 ## Features
 
@@ -23,8 +27,9 @@
 
 CADET-semi-analytic has been successfully built and run on the following platforms:
 
-* Linux (Ubuntu 14.04, SLES11 SP3)
-* Mac OS X (10.6.8 Snow Leopard, 10.9 Mavericks).
+* Windows
+* Linux
+* Mac OS X
 
 ### Dependencies
 
@@ -50,7 +55,7 @@ CADET-semi-analytic has been successfully built and run on the following platfor
 5. Call `cmake` and use the environment variables `GMP_ROOT`, `MPFR_ROOT`, `MPC_ROOT`, and `HDF5_ROOT` to point CMake to the top level directories of the installed libraries if it does not find them automatically. Use `-DCMAKE_INSTALL_PREFIX` to tell CMake the installation directory and `DCMAKE_CXX_COMPILER` if you want to use a non-default compiler. On Linux a suitable command might look like this (paths need to be adjusted):
 
   ```
-GMP_ROOT=libs/gmp/ MPFR_ROOT=libs/mpfr/ MPC_ROOT=libs/mpc/ HDF5_ROOT=libs/hdf5/ cmake -DCMAKE_INSTALL_PREFIX=install/ -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_C_COMPILER=gcc-4.8 ../code
+	GMP_ROOT=libs/gmp/ MPFR_ROOT=libs/mpfr/ MPC_ROOT=libs/mpc/ HDF5_ROOT=libs/hdf5/ cmake -DCMAKE_INSTALL_PREFIX=install/ -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_C_COMPILER=gcc-4.8 ../code
   ```
   Note that you need to pass the switch `-DUSE_FADBAD=ON` in order to enable FADBAD++ support.
 6. After CMake has successfully run, the software is compiled and installed by executing `make install`
@@ -64,27 +69,6 @@ Suppose your model is contained in the HDF5 file `model.h5`, then you can do the
 * Compute the chromatogram via
 
   ```
-chrom -i model.h5 -o chromatogram.csv -e 1e-100 -p 250 -P 20 -t 4 --convabs 0 --convrel 0
+	chromatogram.exe model.h5 -o chromatogram.csv -e 1e-100 -p 250 -P 20 -t 4
   ```
   where no extrapolation method is used and, hence, the convergence detection tolerances are set to 0. This command also requests the usage of 250 decimal digits precision arithmetics (but only 20 digits of them are written to file), parallelization using 4 threads, and the total error to be less than 10^(-100). Extrapolation is enabled by adding `-x MET` to the command line, where `MET` is one of `ide`, `ads`, `wem`, `wrm`, `iad`, `lum`, `ltm`, `ibt`, `btm`, `nam`, `rem`, or `sgr`. The results are written to the file `chromatogram.csv`.
-
-* Compute moments via Laplace transform by calling
-
-  ```
-moments -i model.h5 -o moments.csv -p 5000 -P 20 --convabs 1e-100 --convrel 1e-100 -m 100 -n 100 -v --stopsingleconv -e wem
-  ```
-  where the precision is set to 5000 decimal digits (of which 20 are output), the convergence tolerances are set to 10^(-100), Wynn's epsilon algorithm is used for extrapolation, and a maximum of 100 iterations are performed. The extrapolation stops after convergence has been detected, thanks to the `--stopsingleconv` flag and all intermediate results are written to file because of the `-v` flag. This command computes the first 100 moments (`-m 100`) and writes them to the file `moments.csv`.
-
-* Calculate analytical moments up to fourth order for quasi-stationary binding from formulas derived by Qamar et al. (2014):
-
-  ```
-moments -i model.h5 -o moments.csv -p 5000 -P 20 -a
-  ```
-  where the flags have the same meaning as before. **Attention:** A comparison indicates that the analytical formulas for the third and fourth non-central as well as the fourth central moment are impaired, presumably by typographical errors!
-
-* Calculate moments via numerical inverse Laplace transform and adaptive Gauss-Kronrod quadrature using
-
-  ```
-momentQuadrature -i model.h5 -o moments.csv -p 5000 -P 20 -e 1e-100 --quadrel 1e-50 --quadabs 1e-50 -N 10 -M 50 -m 30
-  ```
-  where the precision flags `-P`, `-p` are the same as before, the inverse Laplace transform is calculated with at most 1^(-100) error, the adaptive integration tries to meet 1^(-50) absolute and relative error tolerances (`--quadrel`, `--quadabs`) and may use up to 50 (`-M`) subdivisions and a Gauss-Kronrod rule comprising 61 = 2*30+1 points (`-m`). The command computes the 10th (`-N`) central and non-central moments and writes them to the file `moments.csv`.

--- a/src/chromatogram.cpp
+++ b/src/chromatogram.cpp
@@ -247,8 +247,8 @@ int main(int argc, char** argv)
 		cmd >> (new TCLAP::ValueArg<mpfr::mpreal>("a", "abscissa", "Abscissa in Durbin's method, used as safety margin if error (-e) is given", false, 0, "Float"))->storeIn(&opts.abscissa);
 		cmd >> (new TCLAP::ValueArg<mpfr::mpreal>("e", "error", "Error threshold (default: 1e-10)", false, 1e-10, "Float"))->storeIn(&opts.error);
 		cmd >> (new TCLAP::ValueArg<mpfr::mpreal>("w", "weight", "Weight used to distribute error onto consistency and truncation (default: 0.5)", false, 0.5, "Float"))->storeIn(&opts.errorWeight);
-		cmd >> (new TCLAP::ValueArg<std::size_t>("N", "lapsum", "Maximum number of summands in Durbin's method (Laplace inversion)", false, 0, "Int"))->storeIn(&opts.laplaceSummands);
-		cmd >> (new TCLAP::ValueArg<std::size_t>("n", "hankelsum", "Number of summands in Dini's expansion (Hankel inversion)", false, 0, "Int"))->storeIn(&opts.hankelSummands);
+		cmd >> (new TCLAP::ValueArg<std::size_t>("N", "lapsum", "Maximum number of (Laplace) summands in Durbin's method (Laplace inversion)", false, 0, "Int"))->storeIn(&opts.laplaceSummands);
+		cmd >> (new TCLAP::ValueArg<std::size_t>("n", "hankelsum", "Number of (Hankel) summands in Dini's expansion (Hankel inversion)", false, 0, "Int"))->storeIn(&opts.hankelSummands);
 		cmd >> (new TCLAP::SwitchArg("", "kahan", "Use Kahan summation"))->storeIn(&opts.kahan);
 		cmd >> (new TCLAP::SwitchArg("", "ignorecstr", "Ignore CSTRs in error estimates"))->storeIn(&opts.ignoreCSTR);
 

--- a/src/model/ColumnLikeModel.cpp
+++ b/src/model/ColumnLikeModel.cpp
@@ -251,7 +251,11 @@ bool ColumnWithPoreDiffusion::configure(io::IParameterProvider& paramProvider)
 		throw InvalidParameterException("Field PAR_DIFFUSION has to have 1 or " + std::to_string(numParType) + " elements");
 	_parDiffusion = std::move(toMPreal(parDiffusion, numParType));
 
-	const std::vector<double> parSurfDiffusion = paramProvider.getDoubleArray("PAR_SURFDIFFUSION");
+	std::vector<double> parSurfDiffusion;
+	if (paramProvider.exists("PAR_SURFDIFFUSION"))
+		parSurfDiffusion = paramProvider.getDoubleArray("PAR_SURFDIFFUSION");
+	else
+		parSurfDiffusion = { 0.0 };
 	if ((parSurfDiffusion.size() != 1) && (parSurfDiffusion.size() != numBound))
 		throw InvalidParameterException("Field PAR_SURFDIFFUSION has to have 1 or " + std::to_string(numBound) + " elements");
 	_parSurfDiffusion = std::move(toMPreal(parSurfDiffusion, numBound));

--- a/src/model/ConvectionDispersionLikeModel.cpp
+++ b/src/model/ConvectionDispersionLikeModel.cpp
@@ -47,6 +47,13 @@ bool ConvectionDispersionLikeModel::configure(io::IParameterProvider& paramProvi
 {
 	UnitOperation::configure(paramProvider);
 
+	if (paramProvider.exists("NCOMP")) // to prevent misuse of files that were set up for e.g. CADET-Core
+	{
+		const int nComp = paramProvider.getInt("NCOMP");
+		if (nComp != 1)
+			throw InvalidParameterException("CADET-semi-analytic only supports single component systems, but NCOMP was specified as " + std::to_string(nComp));
+	}
+
 	// Read geometry parameters
 	_colLength = paramProvider.getDouble("COL_LENGTH");
 


### PR DESCRIPTION
This PR adapts the interface to match CADET-Core, namely by using 0.0 surface diffusion per default and by adding an exception for multi component systems to ease the interchangable use of cadet files.
Further, some maintenance and documentation issues are fixed.