### PR TITLE
Add h5 as output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,13 @@ Suppose your model is contained in the HDF5 file `model.h5`, then you can comput
   ```
 	casema-cli.exe model.h5 -o chromatogram.csv -e 1e-100 -p 250 -P 20 -t 4
   ```
-  where no extrapolation method is used and, hence, the convergence detection tolerances are set to 0. This command also requests the usage of 250 decimal digits precision arithmetics (but only 20 digits of them are written to file), parallelization using 4 threads, and the total error to be less than 10^(-100). Extrapolation is enabled by adding `-x MET` to the command line, where `MET` is one of `ide`, `ads`, `wem`, `wrm`, `iad`, `lum`, `ltm`, `ibt`, `btm`, `nam`, `rem`, or `sgr`. The results are written to the file `chromatogram.csv`.
+  where no extrapolation method is used and, hence, the convergence detection tolerances are set to 0.
+  This command also requests the usage of 250 decimal digits precision arithmetics (but only 20 digits of them are written to file), parallelization using 4 threads, and the total error to be less than 10^(-100).
+  Extrapolation is enabled by adding `-x MET` to the command line, where `MET` is one of `ide`, `ads`, `wem`, `wrm`, `iad`, `lum`, `ltm`, `ibt`, `btm`, `nam`, `rem`, or `sgr`.
+  The results are written to the file `chromatogram.csv`.
+
+Alternatively, you can choose to write the output to the H5 input file, following the CADET file format.
+Note, however, that in this mode, the output precision is constrained by the H5 format, which does not support arbitrary precision, and is instead limited by the numerical limits of the C++ double type.
+  ```
+	casema-cli.exe model.h5 -e 1e-100 -p 250 -P 20 -t 4
+  ```

--- a/include/VersionInfo.hpp
+++ b/include/VersionInfo.hpp
@@ -29,6 +29,7 @@ namespace casema
 	const char* getCompiler() CASEMA_NOEXCEPT;
 	const char* getCompilerFlags() CASEMA_NOEXCEPT;
 	const char* getBuildHost() CASEMA_NOEXCEPT;
+	const int getFileFormat() CASEMA_NOEXCEPT;
 
 } // namespace casema
 

--- a/src/VersionInfo.cpp.in
+++ b/src/VersionInfo.cpp.in
@@ -26,6 +26,11 @@ namespace casema
 	const char BUILD_HOST[] = "@CMAKE_SYSTEM@";
 	const char COMPILER_FLAGS[] = "@CMAKE_CXX_FLAGS@";
 
+	const int getFileFormat() CASEMA_NOEXCEPT
+	{
+		return 40000; // CADET file format
+	}
+
 	const char* getVersion() CASEMA_NOEXCEPT
 	{
 		return casema::CASEMA_VERSION;


### PR DESCRIPTION
This PR enables h5 as output format. This is optional and comes with the loss of arbitrary precision output. 
The h5 format is useful for our evalution pipelines and is used as the standard cadet simulation output. Also, arbitrary precision is rarely needed.

TODO
-------
- [x] enable h5 output (results and meta) while confirming to the CADET(-Core) file format
- [x] outsource the h5 writeResult code to another function
- [x] Make the specification of output file optional when the input file is an h5 and just write solution to that file (reuse the above function)
- [x] update documentation including a warning about the loss of precision
- [x] 2D data with split ports

Fixes #8 