### PR TITLE
Add radial coordinates output to 2DGRM

### DIFF
--- a/src/model/GeneralRateModel2D.cpp
+++ b/src/model/GeneralRateModel2D.cpp
@@ -121,6 +121,18 @@ bool GeneralRateModel2D::configure(io::IParameterProvider& paramProvider)
 	return true;
 }
 
+const std::vector<mpfr::mpreal>& GeneralRateModel2D::secondaryCoordinates() const CASEMA_NOEXCEPT
+{
+	if (_radialEdges.size() < 2)
+		return _radialEdges;
+
+	std::vector<mpfr::mpreal> coords;
+	for (size_t i = 0; i < _radialEdges.size() - 1; ++i)
+		coords.push_back((_radialEdges[i] + _radialEdges[i + 1]) / 2.0);
+
+	return _radialEdges;
+}
+
 void GeneralRateModel2D::setVelocityFromFlowRate(mpfr::mpreal const* in)
 {
 	const mpfr::mpreal pi = Constants<mpfr::mpreal>::pi();

--- a/src/model/GeneralRateModel2D.hpp
+++ b/src/model/GeneralRateModel2D.hpp
@@ -70,6 +70,7 @@ public:
 	virtual const char* unitOperationName() const CASEMA_NOEXCEPT { return "GENERAL_RATE_MODEL_2D"; }
 
 	virtual bool configure(io::IParameterProvider& paramProvider);
+	virtual const std::vector<mpfr::mpreal>& secondaryCoordinates() const CASEMA_NOEXCEPT override;
 
 	virtual void evaluate(const mpfr::mpcomplex& s, Eigen::Ref<Eigen::MatrixCmp> h, Eigen::Ref<Eigen::VectorCmp> g) const CASEMA_NOEXCEPT;
 	virtual void evaluate(const mpfr::mpcomplex& s, const mpfr::mpreal& z, Eigen::Ref<Eigen::MatrixCmp> h, Eigen::Ref<Eigen::VectorCmp> g) const CASEMA_NOEXCEPT;

--- a/src/model/UnitOperation.hpp
+++ b/src/model/UnitOperation.hpp
@@ -73,6 +73,13 @@ public:
 	virtual bool configure(io::IParameterProvider& paramProvider);
 
 	/**
+	 * @brief Returns the secondary spatial coordinates if existent
+	 * @details Unit operations that have a second spatial coordinate can have ports at specific coordinates
+	 * @return secondary spatial coordinates
+	 */
+	virtual const std::vector<mpfr::mpreal>& secondaryCoordinates() const CASEMA_NOEXCEPT { return {}; }
+
+	/**
 	 * @brief Returns the number of components
 	 * @details It is assumed that the number of components is also the number of inputs
 	 *          and outputs of the unit operation.


### PR DESCRIPTION
This PR adds radial coordinates output to 2DGRM to ease order of accuracy tests using CADET-Semi-Analytic as reference