### PR TITLE
Enable manual CI workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit hash, branch name, or tag to run the CI pipeline for'
+        required: false
+        default: 'HEAD'
+        type: string
 
 jobs:
   build:


### PR DESCRIPTION
This PR enables manual execution of the CI workflow from arbitrary branches for arbitrary commits.