### PR TITLE
Add initial condition output at t=0

### DIFF
--- a/doc/interface.md
+++ b/doc/interface.md
@@ -139,7 +139,7 @@ An exception is raised when guaranteed error bounds are not available.
 This mode is **required** when guaranteed error bounds are not available.
 Guaranteed error bounds are not available in:
   - cyclic systems
-  - if any unit operation has initial conditions $> 0$
+  - if any unit operation has non-zero initial conditions
   - CSTRs with variable volume
   - GRM with surface diffusion and kinetic adsorption
   - 2D models (2DGRM). Here, the user must additionally supply a positive `-n <hankel-summands>`.

--- a/src/casema-cli.cpp
+++ b/src/casema-cli.cpp
@@ -349,7 +349,7 @@ void writeMetaAndResultToH5(const ProgramOptions& opts, const casema::model::Mod
 			// Write initial condition at t=0 if timeOffset = 1
 			if (timeOffset == 1)
 			{
-				solutionBuffer[0] = 0.0;
+				solutionBuffer[0] = static_cast<double>(sys->initialOutletValue(j, k));
 				for (int i = 1; i < timePoints; i++)
 					solutionBuffer[i] = static_cast<double>(output(numWrittenOutlets, i - 1));
 			}
@@ -454,12 +454,16 @@ void writeResult(std::ostream& fs, const std::vector<mpfr::mpreal>& time, const 
 	fs.flags(std::ios::scientific);
 	fs.precision(precision);
 
-	// If timeOffset = 1, write initial condition (t=0) with zero concentrations
+	// If timeOffset = 1, write initial condition (t=0) from model-specific initial values
 	if (timeOffset == 1)
 	{
 		fs << time[0];
-		for (std::size_t j = 0; j < numOutlets; ++j)
-			fs << "," << mpfr::mpreal(0);
+		for (std::size_t j = 0; j < numUnits; ++j)
+		{
+			casema::model::UnitOperation const* const m = model.unitOperation(j);
+			for (int k = 0; k < std::max(1, m->numOutletPorts()); ++k)
+				fs << "," << model.initialOutletValue(j, k);
+		}
 		fs << "\n";
 	}
 

--- a/src/casema-cli.cpp
+++ b/src/casema-cli.cpp
@@ -320,7 +320,7 @@ void writeMetaAndResultToH5(const ProgramOptions& opts, const casema::model::Mod
 
 	writer->pushGroup("solution");
 
-	const int timePoints = solutionTimes.size() - timeOffset;
+	const int timePoints = solutionTimes.size();
 	std::vector<double> solutionBuffer(timePoints);
 
 	const int numUnits = sys->numModels();
@@ -328,7 +328,7 @@ void writeMetaAndResultToH5(const ProgramOptions& opts, const casema::model::Mod
 	int numWrittenOutlets = 0;
 
 	for (int i = 0; i < timePoints; i++)
-		solutionBuffer[i] = static_cast<double>(solutionTimes[i + timeOffset]);
+		solutionBuffer[i] = static_cast<double>(solutionTimes[i]);
 
 	writer->writeVectorDouble("SOLUTION_TIMES", timePoints, solutionBuffer.data(), 1, timePoints);
 
@@ -346,8 +346,18 @@ void writeMetaAndResultToH5(const ProgramOptions& opts, const casema::model::Mod
 		// always split ports
 		for (int k = 0; k < nPorts; ++k)
 		{
-			for (int i = 0; i < timePoints; i++)
-				solutionBuffer[i] = static_cast<double>(output(numWrittenOutlets, i));
+			// Write initial condition at t=0 if timeOffset = 1
+			if (timeOffset == 1)
+			{
+				solutionBuffer[0] = 0.0;
+				for (int i = 1; i < timePoints; i++)
+					solutionBuffer[i] = static_cast<double>(output(numWrittenOutlets, i - 1));
+			}
+			else
+			{
+				for (int i = 0; i < timePoints; i++)
+					solutionBuffer[i] = static_cast<double>(output(numWrittenOutlets, i));
+			}
 
 			oss << std::setw(3) << std::setfill('0') << k;
 			const std::string outName = (single_as_multi_port || nPorts > 1) ? "SOLUTION_OUTLET_PORT_" + oss.str() : "SOLUTION_OUTLET";
@@ -443,6 +453,15 @@ void writeResult(std::ostream& fs, const std::vector<mpfr::mpreal>& time, const 
 
 	fs.flags(std::ios::scientific);
 	fs.precision(precision);
+
+	// If timeOffset = 1, write initial condition (t=0) with zero concentrations
+	if (timeOffset == 1)
+	{
+		fs << time[0];
+		for (std::size_t j = 0; j < numOutlets; ++j)
+			fs << "," << mpfr::mpreal(0);
+		fs << "\n";
+	}
 
 	for (std::size_t i = 0; i < time.size() - timeOffset; ++i)
 	{

--- a/src/model/ConvectionDispersionLikeModel.cpp
+++ b/src/model/ConvectionDispersionLikeModel.cpp
@@ -109,6 +109,8 @@ bool ConvectionDispersionLikeModel::configure(io::IParameterProvider& paramProvi
 	}
 */
 
+	if(paramProvider.isArray("INIT_C"))
+		throw InvalidParameterException("Only scalar INIT_C supported");
 	_initC = paramProvider.getDouble("INIT_C");
 
 	return true;

--- a/src/model/ConvectionDispersionLikeModel.hpp
+++ b/src/model/ConvectionDispersionLikeModel.hpp
@@ -47,6 +47,7 @@ public:
 
 	virtual bool hasValidEstimate() const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal estimate(const mpfr::mpreal& abscissa) const CASEMA_NOEXCEPT;
+	virtual mpfr::mpreal initialOutletValue(int) const CASEMA_NOEXCEPT { return _initC; }
 	virtual mpfr::mpreal timeDomainUpperBound(mpfr::mpreal const* in) const CASEMA_NOEXCEPT { return in[0] + _initC; }
 	virtual mpfr::mpreal truncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& nTerms) const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal inverseTruncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& error) const CASEMA_NOEXCEPT;

--- a/src/model/InletModel.cpp
+++ b/src/model/InletModel.cpp
@@ -161,6 +161,34 @@ mpfr::mpreal InletModel::estimate(const mpfr::mpreal& abscissa) const CASEMA_NOE
 	return val;
 }
 
+mpfr::mpreal InletModel::initialOutletValue(int port) const CASEMA_NOEXCEPT
+{
+	(void)port;
+
+	if (_const.empty())
+		return mpfr::mpreal(0.0);
+
+	const mpfr::mpreal t0(0.0);
+
+	if (_sectionTimes.size() >= 2)
+	{
+		const int maxSec = std::min<int>(static_cast<int>(_const.size()), static_cast<int>(_sectionTimes.size()) - 1);
+		for (int i = 0; i < maxSec; ++i)
+		{
+			if ((_sectionTimes[i] <= t0) && (t0 <= _sectionTimes[i + 1]))
+			{
+				const mpfr::mpreal dt = t0 - _sectionTimes[i];
+				return _const[i] + dt * (_lin[i] + dt * (_quad[i] + dt * _cub[i]));
+			}
+		}
+
+		if (t0 < _sectionTimes.front())
+			return mpfr::mpreal(0.0);
+	}
+
+	return _const.front();
+}
+
 mpfr::mpreal InletModel::timeDomainUpperBound(mpfr::mpreal const* in) const CASEMA_NOEXCEPT
 {
 	// Find maximum of nonnegative cubic spline

--- a/src/model/InletModel.hpp
+++ b/src/model/InletModel.hpp
@@ -61,6 +61,7 @@ public:
 
 	virtual bool hasValidEstimate() const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal estimate(const mpfr::mpreal& abscissa) const CASEMA_NOEXCEPT;
+	virtual mpfr::mpreal initialOutletValue(int port) const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal timeDomainUpperBound(mpfr::mpreal const* in) const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal truncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& nTerms) const CASEMA_NOEXCEPT { return -1; }
 	virtual mpfr::mpreal inverseTruncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& error) const CASEMA_NOEXCEPT { return 0; }

--- a/src/model/ModelSystem.cpp
+++ b/src/model/ModelSystem.cpp
@@ -893,6 +893,44 @@ bool ModelSystem::hasValidEstimate() const CASEMA_NOEXCEPT
 	return true;
 }
 
+mpfr::mpreal ModelSystem::initialOutletValue(int unitIdx, int outletPort) const CASEMA_NOEXCEPT
+{
+	if ((unitIdx < 0) || (unitIdx >= static_cast<int>(_models.size())))
+		return mpfr::mpreal(0.0);
+
+	UnitOperation const* const unit = _models[unitIdx];
+
+	if (unit->numOutletPorts() > 0)
+		return unit->initialOutletValue(outletPort);
+
+	if (unit->numInletPorts() <= 0)
+		return mpfr::mpreal(0.0);
+
+	if ((outletPort < 0) || (outletPort >= unit->numInletPorts()))
+		return mpfr::mpreal(0.0);
+
+	// OUTLET-like units (no own outlet state) mirror their inlet at t=0.
+	const int row = _offsetUnitInlet[unitIdx] + outletPort * unit->numComponents();
+	mpfr::mpreal initVal(0.0);
+
+	for (int srcIdx = 0; srcIdx < static_cast<int>(_models.size()); ++srcIdx)
+	{
+		UnitOperation const* const src = _models[srcIdx];
+		if (src->numOutletPorts() <= 0)
+			continue;
+
+		for (int srcPort = 0; srcPort < src->numOutletPorts(); ++srcPort)
+		{
+			const int col = _offsetUnitOutlet[srcIdx] + srcPort * src->numComponents();
+			const mpfr::mpreal frac = _flowMatQtR(row, col);
+			if (frac != 0.0)
+				initVal += frac * src->initialOutletValue(srcPort);
+		}
+	}
+
+	return initVal;
+}
+
 mpfr::mpreal ModelSystem::timeDomainUpperBound() const CASEMA_NOEXCEPT
 {
 	mpfr::mpreal v(0.0);

--- a/src/model/ModelSystem.hpp
+++ b/src/model/ModelSystem.hpp
@@ -72,6 +72,7 @@ public:
 	void evaluate(const mpfr::mpcomplex& s, mpfr::mpcomplex* res, Workspace& ws) const CASEMA_NOEXCEPT;
 
 	bool hasValidEstimate() const CASEMA_NOEXCEPT;
+	mpfr::mpreal initialOutletValue(int unitIdx, int outletPort) const CASEMA_NOEXCEPT;
 	mpfr::mpreal timeDomainUpperBound() const CASEMA_NOEXCEPT;
 	mpfr::mpreal truncationError(const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& nTerms) const CASEMA_NOEXCEPT;
 	mpfr::mpreal inverseTruncationError(const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& error) const CASEMA_NOEXCEPT;

--- a/src/model/StirredTankModel.hpp
+++ b/src/model/StirredTankModel.hpp
@@ -66,6 +66,7 @@ public:
 
 	virtual bool hasValidEstimate() const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal estimate(const mpfr::mpreal& abscissa) const CASEMA_NOEXCEPT;
+	virtual mpfr::mpreal initialOutletValue(int) const CASEMA_NOEXCEPT { return _initC; }
 	virtual mpfr::mpreal timeDomainUpperBound(mpfr::mpreal const* in) const CASEMA_NOEXCEPT { return in[0] + _initC; }
 	virtual mpfr::mpreal truncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& nTerms) const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal inverseTruncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& error) const CASEMA_NOEXCEPT;

--- a/src/model/UnitOperation.cpp
+++ b/src/model/UnitOperation.cpp
@@ -123,6 +123,12 @@ bool UnitOperation::configure(io::IParameterProvider& paramProvider)
 	return true;
 }
 
+mpfr::mpreal UnitOperation::initialOutletValue(int port) const CASEMA_NOEXCEPT
+{
+	(void)port;
+	return mpfr::mpreal(0.0);
+}
+
 }  // namespace model
 
 }  // namespace casema

--- a/src/model/UnitOperation.hpp
+++ b/src/model/UnitOperation.hpp
@@ -148,6 +148,7 @@ public:
 
 	virtual bool hasValidEstimate() const CASEMA_NOEXCEPT = 0;
 	virtual mpfr::mpreal estimate(const mpfr::mpreal& abscissa) const CASEMA_NOEXCEPT = 0;
+	virtual mpfr::mpreal initialOutletValue(int port) const CASEMA_NOEXCEPT;
 	virtual mpfr::mpreal timeDomainUpperBound(mpfr::mpreal const* in) const CASEMA_NOEXCEPT = 0;
 	virtual mpfr::mpreal truncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& nTerms) const CASEMA_NOEXCEPT = 0;
 	virtual mpfr::mpreal inverseTruncationError(const mpfr::mpreal& M, const mpfr::mpreal& abscissa, const mpfr::mpreal& T, const mpfr::mpreal& error) const CASEMA_NOEXCEPT = 0;


### PR DESCRIPTION
The Laplace domain solution solution has a pole at $t=0$, which is why this time point is not considered when computing the solution at all `USER_SOLUTION_TIMES`. This commit adds the initial condition at t=0 to the solution output when t=0 is included in the `USER_SOLUTION_TIMES`, improving consistency with the CADET file format.
- ColumnLikeUnit returns `initC`
- InletModel returns inlet value at $t=0$
- OutletModel returns initial value of upstream connected unit