### PR TITLE
Add exception for invalid pore diffusion

### DIFF
--- a/src/model/ColumnLikeModel.cpp
+++ b/src/model/ColumnLikeModel.cpp
@@ -249,6 +249,8 @@ bool ColumnWithPoreDiffusion::configure(io::IParameterProvider& paramProvider)
 		else
 			_parCoreRadius.push_back(0.0);
 
+		if(paramProvider.getDouble("PORE_DIFFUSION") <= 0.0)
+			throw InvalidParameterException("Field PORE_DIFFUSION has to be > 0.0. To effectively disable particles, set FILM_DIFFUSION to zero.");
 		_parDiffusion.push_back(paramProvider.getDouble("PORE_DIFFUSION"));
 
 		if (paramProvider.exists("SURFACE_DIFFUSION"))


### PR DESCRIPTION
Since CASEMA only supports the 2DGRM, and $D^p=0.0$ leads to zero divisions, we need to prohibit such configurations. The error message recommends setting film_diffusion to zero to effectively disable particles, while pore_diffusion has to remain positive since the grm particle operations are still conducted.